### PR TITLE
Add ansible docs as google first find site:docs.ansible.com

### DIFF
--- a/goto_documentation.sublime-settings
+++ b/goto_documentation.sublime-settings
@@ -10,6 +10,8 @@
         //  - %(query)s the selected text/word
         //  - %(scope)s the current scope
        "css": "http://devdocs.io/#q=%(scope)s+%(query)s",
+       // ansible docs as google first find with site:docs.ansible.com
+       "ansible": "http://www.google.com/search?hl=en&btnI=1&oq=%(query)s+site%%3Adocs.ansible.com&q=%(query)s+site%%3Adocs.ansible.com",
 
         // we can also have an object to
         // run a command for finding docs


### PR DESCRIPTION
Notice that ansible across versions changed naming pattern, so it's better to use google first find within docs.